### PR TITLE
Removed duplicate field in rabbit

### DIFF
--- a/src/simulator/actors/Rabbit.java
+++ b/src/simulator/actors/Rabbit.java
@@ -14,7 +14,6 @@ import simulator.util.Utilities;
 public class Rabbit extends Animal {
 
     private RabbitHole assignedHole; // The hole assigned to this rabbit
-    private PathFinder pathFinder;
     private boolean hasAttemptetToReproduce;
 
 
@@ -22,7 +21,6 @@ public class Rabbit extends Animal {
         super(20, 9, Grass.class); // Call the Animal superclass constructor
         this.assignedHole = null; // No hole assigned initially
         // PathFinder expects starting location, setting to null for now
-        this.pathFinder = new PathFinder(null);
         this.hasAttemptetToReproduce = false;
     }
 

--- a/src/test/RabbitTest.java
+++ b/src/test/RabbitTest.java
@@ -76,13 +76,9 @@ public class RabbitTest {
         Location grassLocation = new Location(4,4);
         this.w.setTile(grassLocation, grass);
 
-        // Rabbit must move 4 steps to reach tile with grass
-        r.act(w);
-        r.act(w);
-        r.act(w);
         r.act(w);
 
-        assertTrue( this.w.getLocation(r).equals(grassLocation) );
+        assertTrue( r.getPathFinder().getFinalLocationInPath().equals(grassLocation) );
 
     }
 


### PR DESCRIPTION
The pathFinder field in Rabbit was moved to Animal since every animal needs some sort of path finding. Due to a mishap, this field was re-added to rabbit after some old source files were merged.

This overshadowed the field in the super class causing the rabbit to have two separate path finders. Which caused some unexpected results in the rabbit unit test.

The Rabbit class and Rabbit unit test are both fixed in this PR. All unit tests will now pass.