### PR TITLE
Fixed oversight in world loader to ensure that specified coordinates are not overshadowed

### DIFF
--- a/src/test/WorldLoaderTest.java
+++ b/src/test/WorldLoaderTest.java
@@ -29,6 +29,8 @@ class WorldLoaderTest {
         assertTrue(wl.getNonBlockables().size() == 3);
         assertTrue(wl.getAnimals().size() == 0);
 
+        assertTrue( this.wl.getProgram().getWorld().getEntities().keySet().size() == wl.getNonBlockables().size() + wl.getAnimals().size() );
+
         List<NonBlockable> nonBlockables = wl.getNonBlockables();
         for(NonBlockable nb : nonBlockables) {
             if(!(nb instanceof Grass)) {
@@ -48,6 +50,8 @@ class WorldLoaderTest {
         assertTrue(wl.getWorldSize() == 10);
         assertTrue(wl.getNonBlockables().size() == 1);
         assertTrue(wl.getAnimals().size() == 0);
+
+        assertTrue( this.wl.getProgram().getWorld().getEntities().keySet().size() == wl.getNonBlockables().size() + wl.getAnimals().size() );
 
         List<NonBlockable> nonBlockables = wl.getNonBlockables();
         for(NonBlockable nb : nonBlockables) {
@@ -72,6 +76,7 @@ class WorldLoaderTest {
         assertTrue(wl.getWorldSize() == 10);
         assertTrue(nonBlockables.size() >= 20 && nonBlockables.size() <= 30);
         assertTrue(wl.getAnimals().size() == 1);
+        assertTrue( this.wl.getProgram().getWorld().getEntities().keySet().size() == wl.getNonBlockables().size() + wl.getAnimals().size() );
 
         for(NonBlockable nb : nonBlockables) {
             if(!(nb instanceof Grass)) {
@@ -100,6 +105,7 @@ class WorldLoaderTest {
         assertTrue(wl.getWorldSize() == 5);
         assertTrue(nonBlockables.size() == 0);
         assertTrue(wl.getAnimals().size() == 1);
+        assertTrue( this.wl.getProgram().getWorld().getEntities().keySet().size() == wl.getNonBlockables().size() + wl.getAnimals().size() );
 
         for(Animal animal : wl.getAnimals()) {
             if(!(animal instanceof Rabbit)) {
@@ -122,6 +128,7 @@ class WorldLoaderTest {
         assertTrue(wl.getWorldSize() == 5);
         assertTrue(nonBlockables.size() == 0);
         assertTrue(animals.size() == 2);
+        assertTrue( this.wl.getProgram().getWorld().getEntities().keySet().size() == wl.getNonBlockables().size() + wl.getAnimals().size() );
 
         for(Animal animal : wl.getAnimals()) {
             if(!(animal instanceof Rabbit)) {
@@ -144,6 +151,7 @@ class WorldLoaderTest {
         assertTrue(wl.getWorldSize() == 10);
         assertTrue(nonBlockables.size() >= 3 && nonBlockables.size() <= 10);
         assertTrue(animals.size() >= 2 && animals.size() <= 4);
+        assertTrue( this.wl.getProgram().getWorld().getEntities().keySet().size() == wl.getNonBlockables().size() + wl.getAnimals().size() );
 
         for(Animal animal : wl.getAnimals()) {
             if(!(animal instanceof Rabbit)) {
@@ -171,6 +179,7 @@ class WorldLoaderTest {
         assertTrue(wl.getWorldSize() == 15);
         assertTrue(nonBlockables.size() == 0);
         assertTrue(animals.size() == 4);
+        assertTrue( this.wl.getProgram().getWorld().getEntities().keySet().size() == wl.getNonBlockables().size() + wl.getAnimals().size() );
 
         for(Animal animal : wl.getAnimals()) {
             if(!(animal instanceof Rabbit)) {
@@ -194,6 +203,7 @@ class WorldLoaderTest {
         assertTrue(wl.getWorldSize() == 15);
         assertTrue(nonBlockables.size() == 1);
         assertTrue(animals.size() == 5);
+        assertTrue( this.wl.getProgram().getWorld().getEntities().keySet().size() == wl.getNonBlockables().size() + wl.getAnimals().size() );
 
         for(Animal animal : wl.getAnimals()) {
             if(!(animal instanceof Rabbit)) {
@@ -222,6 +232,7 @@ class WorldLoaderTest {
         assertTrue(wl.getWorldSize() == 15);
         assertTrue(nonBlockables.size() == 1);
         assertTrue(animals.size() == 5);
+        assertTrue( this.wl.getProgram().getWorld().getEntities().keySet().size() == wl.getNonBlockables().size() + wl.getAnimals().size() );
 
         for(Animal animal : wl.getAnimals()) {
             if(!(animal instanceof Rabbit)) {
@@ -250,6 +261,7 @@ class WorldLoaderTest {
         assertTrue(wl.getWorldSize() == 15);
         assertTrue(nonBlockables.size() == 3);
         assertTrue(animals.size() >= 3 && animals.size() <= 7);
+        assertTrue( this.wl.getProgram().getWorld().getEntities().keySet().size() == wl.getNonBlockables().size() + wl.getAnimals().size() );
 
         for(Animal animal : wl.getAnimals()) {
             if(!(animal instanceof Rabbit)) {
@@ -278,6 +290,7 @@ class WorldLoaderTest {
         assertTrue(wl.getWorldSize() == 5);
         assertTrue(nonBlockables.size() == 0);
         assertTrue(animals.size() == 1);
+        assertTrue( this.wl.getProgram().getWorld().getEntities().keySet().size() == wl.getNonBlockables().size() + wl.getAnimals().size() );
 
         for(Animal animal : wl.getAnimals()) {
             if(!(animal instanceof Wolf)) {
@@ -301,6 +314,7 @@ class WorldLoaderTest {
         assertTrue(wl.getWorldSize() == 10);
         assertTrue(nonBlockables.size() >= 2 && nonBlockables.size() <= 7);
         assertTrue(animals.size() == 3);
+        assertTrue( this.wl.getProgram().getWorld().getEntities().keySet().size() == wl.getNonBlockables().size() + wl.getAnimals().size() );
 
         final int expectedWolfCount = 1;
         final int expectedRabbitCount = 2;


### PR DESCRIPTION
Currently, when the world loader adds new animals and objects to the world, it does so while going through the input file line by line.

This, however, is problematic since it could result in valid specified coordinates to be overshadowed. For example, take this
input file:

3
Rabbit 1
Bear 1 (0,0)

If rabbit is placed randomly at first, then there's a chance that it will end up on tile (0,0), which means the bear doesn't get placed on the specified tile. This is problematic since the coordinate (0,0) should clearly be free here.

A patch for this has been added in this commit.